### PR TITLE
Prevent failure during do_ReadPropertyMultipleRequest

### DIFF
--- a/bacpypes3/constructeddata.py
+++ b/bacpypes3/constructeddata.py
@@ -1396,7 +1396,7 @@ class Array(ExtendedList, metaclass=ArrayMetaclass):
             value = await value
 
         # check the index
-        if index is not None:
+        if index is not None and value is not None:
             if (index < 0) or (index > len(value)):
                 raise PropertyError("invalidArrayIndex")
             if index == 0:


### PR DESCRIPTION
sending a ReadMultipleRequest to a property that does not exist on this object together with an array index, results in "TypeError: object of type 'NoneType' has no len()".

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/bacpypes3/app.py", line 899, in indication
    await helperFn(apdu)
  File "/usr/bin/BACnetIOHandler.py", line 1228, in do_ReadPropertyMultipleRequest
    await super().do_ReadPropertyMultipleRequest(apdu)
  File "/usr/local/lib/python3.12/site-packages/bacpypes3/service/object.py", line 772, in do_ReadPropertyMultipleRequest
    read_access_result_element = await read_property_to_result_element(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bacpypes3/service/object.py", line 430, in read_property_to_result_element
    read_result.propertyValue = await read_property_to_any(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bacpypes3/service/object.py", line 381, in read_property_to_any
    value = await obj.read_property(propertyIdentifier, propertyArrayIndex)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bacpypes3/object.py", line 434, in read_property
    value = await element.read_property(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bacpypes3/constructeddata.py", line 1400, in read_property
    if (index < 0) or (index > len(value)):
                               ^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```
In my case, priorityArray was being read along with an index. Property didn't exist, so it threw the TypeError and failed to create a proper response.

When value is None, can't use len(value) as that results in TypeError at line 1400. 
Proposed change is to not check at all for array index if there is no value.
This should result in the unknownProperty error, which is expected when the property doesn't exist.