### PR TITLE
SubscriptionContextManager Issue when getting ErrorRejectAbortNack

### DIFF
--- a/bacpypes3/service/cov.py
+++ b/bacpypes3/service/cov.py
@@ -79,6 +79,9 @@ class SubscriptionContextManager:
         # timer handle to refresh the subscription
         self.refresh_subscription_handle = None
 
+        # result of refresh task to check if exception occurred
+        self.refresh_subscription_task = None
+
     async def __aenter__(self) -> SubscriptionContextManager:
         if _debug:
             SubscriptionContextManager._debug("__aenter__")


### PR DESCRIPTION
When entering the context manager through __aenter__(), self.refresh_subscription() gets handled just fine.

When called from a TimeHandle through loop.call_later and a device that's been subscribed to doesn't respond, it results in the ErrorRejectAbortNack exception not being propagated to the task that's running the context manager. Instead, the task finishes without ever raising an exception.

When initialising self.refresh_subscription_task as None in __init__(), it's possible to poll in the context manager for any results, and if there is a result, the exception can be called, for example like so:

```       
try:
    async with self.change_of_value(
        address=device_address,
        monitored_object_identifier=object_identifier,
        subscriber_process_identifier=None,
        issue_confirmed_notifications=confirmed_notification,
        lifetime=lifetime,
    ) as subscription:

        while True:
            try:
                property_identifier, property_value = await asyncio.wait_for(
                    subscription.get_value(), 10
                )

            except asyncio.TimeoutError:
                if not isinstance(subscription.refresh_subscription_task, asyncio.Task):
                    continue

                if subscription.refresh_subscription_task.done():
                    subscription.refresh_subscription_task.result()
                continue

except ErrorRejectAbortNack as err:
    pass
```

This way, when running multiple tasks running multiple CoV subscriptions, it's easier to close the subscription task when no response has been received. Let me know if you prefer me making an issue first before making a pull request for future problems.