### PR TITLE
Fix: Inherit BinaryValueObjectCmd from local BinaryValueObject

### DIFF
--- a/bacpypes3/local/binary.py
+++ b/bacpypes3/local/binary.py
@@ -155,7 +155,7 @@ class BinaryValueObject(_Object, _BinaryValueObject):
 
 
 @bacpypes_debugging
-class BinaryValueObjectCmd(Commandable, _BinaryValueObject):
+class BinaryValueObjectCmd(Commandable, BinaryValueObject):
     """
     Commandable Binary Value Object
     """


### PR DESCRIPTION
https://github.com/JoelBender/BACpypes3/issues/131
Ref 131